### PR TITLE
Fix offerings

### DIFF
--- a/tbdex/offering.go
+++ b/tbdex/offering.go
@@ -95,7 +95,7 @@ func (o Offering) Digest() ([]byte, error) {
 }
 
 // Sign cryptographically signs the Resource using DID's private key
-func (o Offering) Sign(bearerDID did.BearerDID) error {
+func (o *Offering) Sign(bearerDID did.BearerDID) error {
 	o.From = bearerDID.URI
 
 	signature, err := Sign(o, bearerDID)

--- a/tbdex/offering_create.go
+++ b/tbdex/offering_create.go
@@ -43,9 +43,9 @@ func CreateOffering(payin OfferingPayinDetails, payout OfferingPayoutDetails, ra
 		ResourceMetadata: ResourceMetadata{
 			Kind:      OfferingKind,
 			ID:        o.id,
-			From:      from,
 			CreatedAt: o.createdAt.UTC().Format(time.RFC3339),
 			UpdatedAt: o.updatedAt.UTC().Format(time.RFC3339),
+			Protocol:  o.protocol,
 		},
 		OfferingData: OfferingData{
 			Payin:       payin,

--- a/tbdex/offering_create.go
+++ b/tbdex/offering_create.go
@@ -13,7 +13,7 @@ import (
 // An Offering is a resource created by a PFI to define requirements for a given currency pair offered for exchange.
 //
 // [Offering]: https://github.com/TBD54566975/tbdex/tree/main/specs/protocol#offering
-func CreateOffering(payin OfferingPayinDetails, payout OfferingPayoutDetails, rate string, from string, opts ...CreateOfferingOption) (Offering, error) {
+func CreateOffering(payin OfferingPayinDetails, payout OfferingPayoutDetails, rate string, opts ...CreateOfferingOption) (Offering, error) {
 	defaultID, err := typeid.WithPrefix(OfferingKind)
 	if err != nil {
 		return Offering{}, fmt.Errorf("failed to generate default id: %w", err)

--- a/tbdex/offering_test.go
+++ b/tbdex/offering_test.go
@@ -11,10 +11,7 @@ import (
 )
 
 func TestCreate(t *testing.T) {
-	bearerDID, err := didjwk.Create()
-	assert.NoError(t, err)
-
-	_, err = tbdex.CreateOffering(
+	_, err := tbdex.CreateOffering(
 		tbdex.WithOfferingPayin(
 			"USD",
 			tbdex.WithOfferingPayinMethod("SQUAREPAY"),
@@ -27,7 +24,6 @@ func TestCreate(t *testing.T) {
 			),
 		),
 		"1.0",
-		bearerDID.URI,
 	)
 
 	assert.NoError(t, err)
@@ -50,7 +46,6 @@ func TestSign(t *testing.T) {
 			),
 		),
 		"1.0",
-		bearerDID.URI,
 	)
 	assert.NoError(t, err)
 
@@ -74,8 +69,9 @@ func TestUnmarshal(t *testing.T) {
 			),
 		),
 		"1.0",
-		bearerDID.URI,
 	)
+
+	o.Sign(bearerDID)
 
 	bytes, err := json.Marshal(o)
 	assert.NoError(t, err)

--- a/tbdex/offering_test.go
+++ b/tbdex/offering_test.go
@@ -71,7 +71,8 @@ func TestUnmarshal(t *testing.T) {
 		"1.0",
 	)
 
-	o.Sign(bearerDID)
+	err := o.Sign(bearerDID)
+	assert.NoError(t, err)
 
 	bytes, err := json.Marshal(o)
 	assert.NoError(t, err)


### PR DESCRIPTION
### Changes

#### removed `from` as required arg for `tbdex.CreateOffering`

`offering.Metadata.From` is set as a byproduct of calling `Sign` since `Sign` takes a bearerDID 

----

#### set `protocol` when creating offering

option existed but wasn't being set on the actual offering 