### PR TITLE
Fix `just-schemas`

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -14,4 +14,4 @@ lint:
 # Copies JSON schemas from the tbdex submodule repo into the protocol dir.
 schemas:
   @git submodule update --init --recursive
-  @cp -r tbdex/hosted/json-schemas protocol/
+  @cp -r spec/hosted/json-schemas tbdex/


### PR DESCRIPTION
# Summary
fixed a derp. 

`tbdex` submodule was renamed to `spec` in https://github.com/TBD54566975/tbdex-go/pull/7 in order to use the `tbdex` directory name for the actual go package but forgot to update the `just schemas` command to reflect