### PR TITLE
change type for `offering.[Payin|Payout].RequiredPaymentDetails`

### DIFF
--- a/tbdex/crypto.go
+++ b/tbdex/crypto.go
@@ -55,7 +55,7 @@ func VerifyDigest(expectedDigest string, payload any) error {
 	if err != nil {
 		return fmt.Errorf("failed to digest while verifying: %w", err)
 	}
-	digestEncodedString := base64.URLEncoding.EncodeToString(digestByteArray)
+	digestEncodedString := base64.RawURLEncoding.EncodeToString(digestByteArray)
 
 	if digestEncodedString != expectedDigest {
 		return fmt.Errorf("digested payload does not equal expected expectedDigest: %w", err)

--- a/tbdex/offering/create.go
+++ b/tbdex/offering/create.go
@@ -1,6 +1,7 @@
 package offering
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -186,7 +187,7 @@ type paymentMethodOptions struct {
 	Fee                    string
 	Name                   string
 	Description            string
-	RequiredPaymentDetails string
+	RequiredPaymentDetails json.RawMessage
 }
 
 // PaymentMethodOption implements functional options pattern for PayinMethod and PayoutMethod.
@@ -237,7 +238,7 @@ func MethodDescription(description string) PaymentMethodOption {
 // RequiredDetails can be passed to [Create] to provide a custom payin method required payment details.
 func RequiredDetails(details string) PaymentMethodOption {
 	return func(pm *paymentMethodOptions) {
-		pm.RequiredPaymentDetails = details
+		pm.RequiredPaymentDetails = json.RawMessage(details)
 	}
 }
 

--- a/tbdex/offering/offering.go
+++ b/tbdex/offering/offering.go
@@ -49,27 +49,27 @@ type PayoutDetails struct {
 
 // PayinMethod represents a single payment option on an Offering.
 type PayinMethod struct {
-	Kind                   string `json:"kind"`
-	Name                   string `json:"name,omitempty"`
-	Description            string `json:"description,omitempty"`
-	Group                  string `json:"group,omitempty"`
-	RequiredPaymentDetails string `json:"requiredPaymentDetails,omitempty"` // TODO: change to JSON Schema type
-	Fee                    string `json:"fee,omitempty"`
-	Min                    string `json:"min,omitempty"`
-	Max                    string `json:"max,omitempty"`
+	Kind                   string          `json:"kind"`
+	Name                   string          `json:"name,omitempty"`
+	Description            string          `json:"description,omitempty"`
+	Group                  string          `json:"group,omitempty"`
+	RequiredPaymentDetails json.RawMessage `json:"requiredPaymentDetails,omitempty"` // TODO: change to JSON Schema type
+	Fee                    string          `json:"fee,omitempty"`
+	Min                    string          `json:"min,omitempty"`
+	Max                    string          `json:"max,omitempty"`
 }
 
 // PayoutMethod contains all the fields from PaymentMethod, in addition to estimated settlement time.
 type PayoutMethod struct {
-	Kind                    string `json:"kind"`
-	Name                    string `json:"name,omitempty"`
-	Description             string `json:"description,omitempty"`
-	Group                   string `json:"group,omitempty"`
-	RequiredPaymentDetails  string `json:"requiredPaymentDetails,omitempty"` // TODO: change to JSON Schema type
-	Fee                     string `json:"fee,omitempty"`
-	Min                     string `json:"min,omitempty"`
-	Max                     string `json:"max,omitempty"`
-	EstimatedSettlementTime uint64 `json:"estimatedSettlementTime"`
+	Kind                    string          `json:"kind"`
+	Name                    string          `json:"name,omitempty"`
+	Description             string          `json:"description,omitempty"`
+	Group                   string          `json:"group,omitempty"`
+	RequiredPaymentDetails  json.RawMessage `json:"requiredPaymentDetails,omitempty"` // TODO: change to JSON Schema type
+	Fee                     string          `json:"fee,omitempty"`
+	Min                     string          `json:"min,omitempty"`
+	Max                     string          `json:"max,omitempty"`
+	EstimatedSettlementTime uint64          `json:"estimatedSettlementTime"`
 }
 
 // ID is a unique identifier for an Offering.

--- a/tbdex/offering/offering_test.go
+++ b/tbdex/offering/offering_test.go
@@ -2,6 +2,7 @@ package offering_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
@@ -53,6 +54,20 @@ func TestUnmarshal(t *testing.T) {
 	bearerDID, err := didjwk.Create()
 	assert.NoError(t, err)
 
+	sch := offering.RequiredDetails(`{
+		"$schema": "http://json-schema.org/draft-07/schema#",
+		"additionalProperties": false,
+		"properties": {
+			"clabe": {
+				"type": "string"
+			},
+			"fullName": {
+				"type": "string"
+			}
+		},
+		"required": ["clabe", "fullName"]
+	}`)
+
 	o, err := offering.Create(
 		offering.NewPayin(
 			"USD",
@@ -60,7 +75,7 @@ func TestUnmarshal(t *testing.T) {
 		),
 		offering.NewPayout(
 			"USDC",
-			[]offering.PayoutMethod{offering.NewPayoutMethod("STORED_BALANCE", 20*time.Minute)},
+			[]offering.PayoutMethod{offering.NewPayoutMethod("STORED_BALANCE", 20*time.Minute, sch)},
 		),
 		"1.0",
 	)
@@ -72,6 +87,8 @@ func TestUnmarshal(t *testing.T) {
 
 	bytes, err := json.Marshal(o)
 	assert.NoError(t, err)
+
+	fmt.Println(string(bytes))
 
 	var o2 offering.Offering
 	err = o2.UnmarshalJSON(bytes)

--- a/tbdex/offering/offering_test.go
+++ b/tbdex/offering/offering_test.go
@@ -2,7 +2,6 @@ package offering_test
 
 import (
 	"encoding/json"
-	"fmt"
 	"testing"
 	"time"
 
@@ -54,7 +53,7 @@ func TestUnmarshal(t *testing.T) {
 	bearerDID, err := didjwk.Create()
 	assert.NoError(t, err)
 
-	sch := offering.RequiredDetails(`{
+	requiredPayoutDetails := offering.RequiredDetails(`{
 		"$schema": "http://json-schema.org/draft-07/schema#",
 		"additionalProperties": false,
 		"properties": {
@@ -75,7 +74,7 @@ func TestUnmarshal(t *testing.T) {
 		),
 		offering.NewPayout(
 			"USDC",
-			[]offering.PayoutMethod{offering.NewPayoutMethod("STORED_BALANCE", 20*time.Minute, sch)},
+			[]offering.PayoutMethod{offering.NewPayoutMethod("STORED_BALANCE", 20*time.Minute, requiredPayoutDetails)},
 		),
 		"1.0",
 	)
@@ -87,8 +86,6 @@ func TestUnmarshal(t *testing.T) {
 
 	bytes, err := json.Marshal(o)
 	assert.NoError(t, err)
-
-	fmt.Println(string(bytes))
 
 	var o2 offering.Offering
 	err = o2.UnmarshalJSON(bytes)

--- a/tbdex/offering/offering_test.go
+++ b/tbdex/offering/offering_test.go
@@ -53,28 +53,30 @@ func TestUnmarshal(t *testing.T) {
 	bearerDID, err := didjwk.Create()
 	assert.NoError(t, err)
 
-	requiredPayoutDetails := offering.RequiredDetails(`{
-		"$schema": "http://json-schema.org/draft-07/schema#",
-		"additionalProperties": false,
-		"properties": {
-			"clabe": {
-				"type": "string"
-			},
-			"fullName": {
-				"type": "string"
-			}
-		},
-		"required": ["clabe", "fullName"]
-	}`)
-
 	o, err := offering.Create(
 		offering.NewPayin(
 			"USD",
 			[]offering.PayinMethod{offering.NewPayinMethod("SQUAREPAY")},
 		),
 		offering.NewPayout(
-			"USDC",
-			[]offering.PayoutMethod{offering.NewPayoutMethod("STORED_BALANCE", 20*time.Minute, requiredPayoutDetails)},
+			"MXN",
+			[]offering.PayoutMethod{offering.NewPayoutMethod(
+				"STORED_BALANCE",
+				20*time.Minute,
+				offering.RequiredDetails(`{
+					"$schema": "http://json-schema.org/draft-07/schema#",
+					"additionalProperties": false,
+					"properties": {
+						"clabe": {
+							"type": "string"
+						},
+						"fullName": {
+							"type": "string"
+						}
+					},
+					"required": ["clabe", "fullName"]
+				}`),
+			)},
 		),
 		"1.0",
 	)


### PR DESCRIPTION
### Summary
* changed `offering.[Payin|Payout].RequiredPaymentDetails` from `string` to [`json.RawMessage`](https://pkg.go.dev/encoding/json#RawMessage)
* fixed base64 url encoding 

### Motivation
`requiredPaymentDetails` was being double stringified. 


### Usage
```go
o, err := offering.Create(
  offering.NewPayin(
    "USD",
    []offering.PayinMethod{offering.NewPayinMethod("SQUAREPAY")},
  ),
  offering.NewPayout(
    "MXN",
    []offering.PayoutMethod{offering.NewPayoutMethod(
      "STORED_BALANCE",
      20*time.Minute,
      offering.RequiredDetails(`{
        "$schema": "http://json-schema.org/draft-07/schema#",
        "additionalProperties": false,
        "properties": {
          "clabe": {
            "type": "string"
          },
          "fullName": {
            "type": "string"
          }
        },
        "required": ["clabe", "fullName"]
      }`),
    )},
  ),
  "1.0",
)
```
> [!NOTE]
> I did consider & try using json schema types from 3rd party libs. there was more DevEx friction imo, bc you have to learn how to use that lib and then our sdk leaks a 3rd party dependency from its API surface