### PR TITLE
bring `offering.Sign` back

### DIFF
--- a/tbdex/offering/create.go
+++ b/tbdex/offering/create.go
@@ -168,6 +168,7 @@ func Description(d string) CreateOption {
 	}
 }
 
+// From can be passed to [Create] in order to create and sign the offering in one fell swoop
 func From(d did.BearerDID) CreateOption {
 	return func(o *createOptions) {
 		o.from = &d

--- a/tbdex/offering/offering.go
+++ b/tbdex/offering/offering.go
@@ -7,6 +7,7 @@ import (
 	"github.com/TBD54566975/tbdex-go/tbdex/crypto"
 	"github.com/TBD54566975/tbdex-go/tbdex/resource"
 	"github.com/TBD54566975/tbdex-go/tbdex/validator"
+	"github.com/tbd54566975/web5-go/dids/did"
 	"github.com/tbd54566975/web5-go/pexv2"
 	"go.jetpack.io/typeid"
 )
@@ -96,6 +97,20 @@ func (o Offering) Digest() ([]byte, error) {
 	}
 
 	return hashed, nil
+}
+
+// Sign cryptographically signs the Resource using DID's private key
+func (o *Offering) Sign(bearerDID did.BearerDID) error {
+	o.Metadata.From = bearerDID.URI
+
+	signature, err := crypto.Sign(o, bearerDID)
+	if err != nil {
+		return fmt.Errorf("failed to sign offering: %w", err)
+	}
+
+	o.Signature = signature
+
+	return nil
 }
 
 // UnmarshalJSON validates and unmarshals the input data into an Offering.

--- a/tbdex/offering/offering_test.go
+++ b/tbdex/offering/offering_test.go
@@ -16,7 +16,6 @@ func TestCreate(t *testing.T) {
 	assert.NoError(t, err)
 
 	_, err = offering.Create(
-		pfiDID,
 		offering.NewPayin(
 			"USD",
 			[]offering.PayinMethod{offering.NewPayinMethod("SQUAREPAY")},
@@ -26,6 +25,7 @@ func TestCreate(t *testing.T) {
 			[]offering.PayoutMethod{offering.NewPayoutMethod("STORED_BALANCE", 20*time.Minute)},
 		),
 		"1.0",
+		offering.From(pfiDID),
 	)
 
 	assert.NoError(t, err)
@@ -36,7 +36,6 @@ func TestSign(t *testing.T) {
 	assert.NoError(t, err)
 
 	offering, err := offering.Create(
-		bearerDID,
 		offering.NewPayin(
 			"USD",
 			[]offering.PayinMethod{offering.NewPayinMethod("SQUAREPAY")},
@@ -46,6 +45,7 @@ func TestSign(t *testing.T) {
 			[]offering.PayoutMethod{offering.NewPayoutMethod("STORED_BALANCE", 20*time.Minute)},
 		),
 		"1.0",
+		offering.From(bearerDID),
 	)
 	assert.NoError(t, err)
 	assert.NotZero(t, offering.Signature)
@@ -56,7 +56,6 @@ func TestUnmarshal(t *testing.T) {
 	assert.NoError(t, err)
 
 	o, err := offering.Create(
-		bearerDID,
 		offering.NewPayin(
 			"USD",
 			[]offering.PayinMethod{offering.NewPayinMethod("SQUAREPAY")},
@@ -82,6 +81,7 @@ func TestUnmarshal(t *testing.T) {
 			)},
 		),
 		"1.0",
+		offering.From(bearerDID),
 	)
 
 	assert.NoError(t, err)
@@ -117,7 +117,6 @@ func TestVerify(t *testing.T) {
 	assert.NoError(t, err)
 
 	o, err := offering.Create(
-		bearerDID,
 		offering.NewPayin(
 			"BTC",
 			[]offering.PayinMethod{offering.NewPayinMethod("BTC_ADDRESS")},
@@ -127,6 +126,7 @@ func TestVerify(t *testing.T) {
 			[]offering.PayoutMethod{offering.NewPayoutMethod("STORED_BALANCE", 20*time.Minute)},
 		),
 		"60000.00",
+		offering.From(bearerDID),
 	)
 
 	assert.NoError(t, err)
@@ -140,7 +140,6 @@ func TestVerify_InvalidSignature(t *testing.T) {
 	assert.NoError(t, err)
 
 	o, err := offering.Create(
-		bearerDID,
 		offering.NewPayin(
 			"BTC",
 			[]offering.PayinMethod{offering.NewPayinMethod("BTC_ADDRESS")},
@@ -150,6 +149,7 @@ func TestVerify_InvalidSignature(t *testing.T) {
 			[]offering.PayoutMethod{offering.NewPayoutMethod("STORED_BALANCE", 20*time.Minute)},
 		),
 		"60000.00",
+		offering.From(bearerDID),
 	)
 
 	assert.NoError(t, err)
@@ -165,7 +165,6 @@ func TestVerify_SignedWithWrongDID(t *testing.T) {
 	wrongDID, _ := didjwk.Create()
 
 	o, err := offering.Create(
-		bearerDID,
 		offering.NewPayin(
 			"BTC",
 			[]offering.PayinMethod{offering.NewPayinMethod("BTC_ADDRESS")},
@@ -175,6 +174,7 @@ func TestVerify_SignedWithWrongDID(t *testing.T) {
 			[]offering.PayoutMethod{offering.NewPayoutMethod("STORED_BALANCE", 20*time.Minute)},
 		),
 		"60000.00",
+		offering.From(bearerDID),
 	)
 
 	assert.NoError(t, err)


### PR DESCRIPTION
we nixed `Sign` per https://github.com/TBD54566975/tbdex-go/issues/29. turns out offerings are updated frequently and therefore need to be re-signed without fully creating a new one.  This PR adds `offering.Sign` back and adds the ability to optionally provide a bearer DID when calling `offering.Create` which provides us with optionality to sign as part of calling `Create` _or_ explicitly calling `Sign` if needed.

Optionally providing bearerDID to `offering.Create`:
```go
bearerDID, _ := didjwk.Create()

o, err := offering.Create(
    offering.NewPayin(
        "BTC",
        []offering.PayinMethod{offering.NewPayinMethod("BTC_ADDRESS")},
    ),
    offering.NewPayout(
        "USDC",
        []offering.PayoutMethod{offering.NewPayoutMethod("STORED_BALANCE", 20*time.Minute)},
    ),
    "60000.00",
    offering.From(bearerDID),
)
```

`offering.From(bearerDID)` is optional