### PR TITLE
add interface method to get message metadata

### DIFF
--- a/tbdex/closemsg/closemsg.go
+++ b/tbdex/closemsg/closemsg.go
@@ -27,12 +27,12 @@ func (c Close) GetMetadata() message.Metadata {
 	return c.Metadata
 }
 
-// Kind returns the kind of message.
+// GetKind returns the kind of message.
 func (c Close) GetKind() string {
 	return c.Metadata.Kind
 }
 
-// ValidNext returns the kinds of messages that can follow a close.
+// GetValidNext returns the kinds of messages that can follow a close.
 func (c Close) GetValidNext() []string {
 	return []string{}
 }

--- a/tbdex/closemsg/closemsg.go
+++ b/tbdex/closemsg/closemsg.go
@@ -22,13 +22,18 @@ type Close struct {
 	Signature string           `json:"signature,omitempty"`
 }
 
+// GetMetadata returns the metadata of the message.
+func (c Close) GetMetadata() message.Metadata {
+	return c.Metadata
+}
+
 // Kind returns the kind of message.
-func (c Close) Kind() string {
+func (c Close) GetKind() string {
 	return c.Metadata.Kind
 }
 
 // ValidNext returns the kinds of messages that can follow a close.
-func (c Close) ValidNext() []string {
+func (c Close) GetValidNext() []string {
 	return []string{}
 }
 

--- a/tbdex/order/order.go
+++ b/tbdex/order/order.go
@@ -36,12 +36,12 @@ func (o Order) GetMetadata() message.Metadata {
 	return o.Metadata
 }
 
-// Kind returns the kind of message
+// GetKind returns the kind of message
 func (o Order) GetKind() string {
 	return o.Metadata.Kind
 }
 
-// ValidNext returns the valid message kinds that can follow an order.
+// GetValidNext returns the valid message kinds that can follow an order.
 func (o Order) GetValidNext() []string {
 	return []string{orderstatus.Kind, closemsg.Kind}
 }

--- a/tbdex/order/order.go
+++ b/tbdex/order/order.go
@@ -31,13 +31,18 @@ type Order struct {
 	Signature string           `json:"signature,omitempty"`
 }
 
+// GetMetadata returns the metadata of the message
+func (o Order) GetMetadata() message.Metadata {
+	return o.Metadata
+}
+
 // Kind returns the kind of message
-func (o Order) Kind() string {
+func (o Order) GetKind() string {
 	return o.Metadata.Kind
 }
 
 // ValidNext returns the valid message kinds that can follow an order.
-func (o Order) ValidNext() []string {
+func (o Order) GetValidNext() []string {
 	return []string{orderstatus.Kind, closemsg.Kind}
 }
 

--- a/tbdex/orderstatus/orderstatus.go
+++ b/tbdex/orderstatus/orderstatus.go
@@ -33,12 +33,12 @@ func (os OrderStatus) GetMetadata() message.Metadata {
 	return os.Metadata
 }
 
-// Kind returns the kind of message
+// GetKind returns the kind of message
 func (os OrderStatus) GetKind() string {
 	return os.Metadata.Kind
 }
 
-// ValidNext returns the valid next message kinds that can follow an orderstatus
+// GetValidNext returns the valid next message kinds that can follow an orderstatus
 func (os OrderStatus) GetValidNext() []string {
 	return []string{Kind, closemsg.Kind}
 }

--- a/tbdex/orderstatus/orderstatus.go
+++ b/tbdex/orderstatus/orderstatus.go
@@ -28,13 +28,18 @@ type OrderStatus struct {
 	Signature string           `json:"signature,omitempty"`
 }
 
+// GetMetadata returns the metadata of the message
+func (os OrderStatus) GetMetadata() message.Metadata {
+	return os.Metadata
+}
+
 // Kind returns the kind of message
-func (os OrderStatus) Kind() string {
+func (os OrderStatus) GetKind() string {
 	return os.Metadata.Kind
 }
 
 // ValidNext returns the valid next message kinds that can follow an orderstatus
-func (os OrderStatus) ValidNext() []string {
+func (os OrderStatus) GetValidNext() []string {
 	return []string{Kind, closemsg.Kind}
 }
 

--- a/tbdex/quote/quote.go
+++ b/tbdex/quote/quote.go
@@ -29,13 +29,18 @@ type Quote struct {
 	Signature string           `json:"signature,omitempty"`
 }
 
+// GetMetadata returns the metadata of the message
+func (q Quote) GetMetadata() message.Metadata {
+	return q.Metadata
+}
+
 // Kind returns the kind of message
-func (q Quote) Kind() string {
+func (q Quote) GetKind() string {
 	return Kind
 }
 
 // ValidNext returns the valid message kinds that can follow a Quote.
-func (q Quote) ValidNext() []string {
+func (q Quote) GetValidNext() []string {
 	return ValidNext()
 }
 

--- a/tbdex/quote/quote.go
+++ b/tbdex/quote/quote.go
@@ -34,12 +34,12 @@ func (q Quote) GetMetadata() message.Metadata {
 	return q.Metadata
 }
 
-// Kind returns the kind of message
+// GetKind returns the kind of message
 func (q Quote) GetKind() string {
 	return Kind
 }
 
-// ValidNext returns the valid message kinds that can follow a Quote.
+// GetValidNext returns the valid message kinds that can follow a Quote.
 func (q Quote) GetValidNext() []string {
 	return ValidNext()
 }

--- a/tbdex/rfq/rfq.go
+++ b/tbdex/rfq/rfq.go
@@ -29,13 +29,18 @@ type RFQ struct {
 	Signature   string           `json:"signature,omitempty"`
 }
 
+// GetMetadata returns the metadata of the message
+func (r RFQ) GetMetadata() message.Metadata {
+	return r.Metadata
+}
+
 // Kind returns the kind of message
-func (r RFQ) Kind() string {
+func (r RFQ) GetKind() string {
 	return Kind
 }
 
 // ValidNext returns the valid message kinds that can follow a RFQ.
-func (r RFQ) ValidNext() []string {
+func (r RFQ) GetValidNext() []string {
 	return ValidNext()
 }
 

--- a/tbdex/rfq/rfq.go
+++ b/tbdex/rfq/rfq.go
@@ -34,12 +34,12 @@ func (r RFQ) GetMetadata() message.Metadata {
 	return r.Metadata
 }
 
-// Kind returns the kind of message
+// GetKind returns the kind of message
 func (r RFQ) GetKind() string {
 	return Kind
 }
 
-// ValidNext returns the valid message kinds that can follow a RFQ.
+// GetValidNext returns the valid message kinds that can follow a RFQ.
 func (r RFQ) GetValidNext() []string {
 	return ValidNext()
 }

--- a/tbdex/tbdex.go
+++ b/tbdex/tbdex.go
@@ -14,9 +14,10 @@ import (
 // Message is the interface that all tbdex messages implement. Especially useful for decoding and parsing messages
 // when the kind of message is not known upfront.
 type Message interface {
-	ValidNext() []string
-	Kind() string
 	Digest() ([]byte, error)
+	GetValidNext() []string
+	GetKind() string
+	GetMetadata() message.Metadata
 	// TODO: uncomment these once rfq has been refactored to separate privateStrict bool
 	// Verify() error
 	// Parse([]byte) (Message, error)


### PR DESCRIPTION
closes #46. Was hoping i could add `Metadata()` but that's already a field name so had to go with `GetMetadata()`. didn't want this function to be the only getter with an explicit `Get` in the method name so i changed `Kind()` to `GetKind()` and `ValidNext()` to `GetValidNext()`

### Motivation
make it easy to get a message's metadata without first converting it to an even narrower type e.g. `rfq.RFQ`, `quote.Quote` etc.