### PR TITLE
add cancel and update offering, logging error for rfq.verifyClaims()

### DIFF
--- a/tbdex/cancel/cancel.go
+++ b/tbdex/cancel/cancel.go
@@ -1,0 +1,195 @@
+package cancel
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/TBD54566975/tbdex-go/tbdex/closemsg"
+	"github.com/TBD54566975/tbdex-go/tbdex/crypto"
+	"github.com/TBD54566975/tbdex-go/tbdex/message"
+	"github.com/TBD54566975/tbdex-go/tbdex/validator"
+	"github.com/tbd54566975/web5-go/dids/did"
+	"go.jetpack.io/typeid"
+)
+
+// Kind identifies this message kind
+const Kind = "cancel"
+
+// ValidNext returns the valid message kinds that can follow a cancel.
+func ValidNext() []string {
+	// todo hardcoded orderstatus kind here because otherwise i am introducing a circular dependency :(
+	return []string{"orderstatus", closemsg.Kind}
+}
+
+// Cancel represents a cancel message within the exchange.
+type Cancel struct {
+	Metadata  message.Metadata `json:"metadata,omitempty"`
+	Data      Data             `json:"data,omitempty"`
+	Signature string           `json:"signature,omitempty"`
+}
+
+// GetMetadata returns the metadata of the message.
+func (c Cancel) GetMetadata() message.Metadata {
+	return c.Metadata
+}
+
+// GetKind returns the kind of message.
+func (c Cancel) GetKind() string {
+	return c.Metadata.Kind
+}
+
+// GetValidNext returns the kinds of messages that can follow a cancel.
+func (c Cancel) GetValidNext() []string {
+	return ValidNext()
+}
+
+// IsValidNext checks if the kind is a valid next message kind for a cancel.
+func (c Cancel) IsValidNext(kind string) bool {
+	for _, k := range ValidNext() {
+		if k == kind {
+			return true
+		}
+	}
+	return false
+}
+
+// Data encapsulates the data content of a cancel.
+type Data struct {
+	Reason string `json:"reason,omitempty"`
+}
+
+// Digest computes a hash of the message
+func (c Cancel) Digest() ([]byte, error) {
+	payload := map[string]any{"metadata": c.Metadata, "data": c.Data}
+
+	hashed, err := crypto.DigestJSON(payload)
+	if err != nil {
+		return nil, fmt.Errorf("failed to digest cancel: %w", err)
+	}
+
+	return hashed, nil
+}
+
+// Verify verifies the signature of the Cancel.
+func (c *Cancel) Verify() error {
+	decoded, err := crypto.VerifySignature(c, c.Signature)
+	if err != nil {
+		return fmt.Errorf("failed to verify cancel signature: %w", err)
+	}
+
+	if decoded.SignerDID.URI != c.Metadata.From {
+		return fmt.Errorf("signer: %s does not match message metadata from: %s", decoded.SignerDID.URI, c.Metadata.From)
+	}
+
+	return nil
+}
+
+// UnmarshalJSON validates and unmarshals the input data into a Cancel.
+func (c *Cancel) UnmarshalJSON(data []byte) error {
+	err := validator.Validate(validator.TypeMessage, data, validator.WithKind(Kind))
+	if err != nil {
+		return fmt.Errorf("invalid cancel: %w", err)
+	}
+
+	ret := cancelType{}
+	err = json.Unmarshal(data, &ret)
+	if err != nil {
+		return fmt.Errorf("failed to JSON unmarshal cancel: %w", err)
+	}
+
+	*c = Cancel(ret)
+
+	return nil
+}
+
+// Parse validates and unmarshals the input data into a Cancel.
+func Parse(data []byte) (Cancel, error) {
+	c := Cancel{}
+	if err := json.Unmarshal(data, &c); err != nil {
+		return Cancel{}, fmt.Errorf("failed to unmarshal Cancel: %w", err)
+	}
+
+	if err := c.Verify(); err != nil {
+		return Cancel{}, fmt.Errorf("failed to verify Cancel: %w", err)
+	}
+
+	return c, nil
+}
+
+// Create creates a new Cancel message.
+func Create(fromDID did.BearerDID, to, exchangeID string, opts ...CreateOption) (Cancel, error) {
+	o := createOptions{
+		id:        typeid.Must(typeid.WithPrefix(Kind)).String(),
+		createdAt: time.Now(),
+		protocol:  "1.0",
+	}
+
+	for _, opt := range opts {
+		opt(&o)
+	}
+
+	c := Cancel{
+		Metadata: message.Metadata{
+			From:       fromDID.URI,
+			To:         to,
+			Kind:       Kind,
+			ID:         o.id,
+			ExchangeID: exchangeID,
+			CreatedAt:  o.createdAt.UTC().Format(time.RFC3339),
+			ExternalID: o.externalID,
+			Protocol:   o.protocol,
+		},
+		Data: Data{Reason: o.reason},
+	}
+
+	signature, err := crypto.Sign(c, fromDID)
+	if err != nil {
+		return Cancel{}, fmt.Errorf("failed to sign cancel: %w", err)
+	}
+
+	c.Signature = signature
+
+	return c, nil
+}
+
+type createOptions struct {
+	id         string
+	createdAt  time.Time
+	protocol   string
+	externalID string
+	reason     string
+}
+
+// CreateOption defines a type for functions that can modify the createOptions struct.
+type CreateOption func(*createOptions)
+
+// ID can be passed to [Create] to provide a custom id.
+func ID(id string) CreateOption {
+	return func(c *createOptions) {
+		c.id = id
+	}
+}
+
+// CreatedAt can be passed to [Create] to provide a custom created at time.
+func CreatedAt(t time.Time) CreateOption {
+	return func(c *createOptions) {
+		c.createdAt = t
+	}
+}
+
+// ExternalID can be passed to [Create] to provide a custom external id.
+func ExternalID(externalID string) CreateOption {
+	return func(c *createOptions) {
+		c.externalID = externalID
+	}
+}
+
+// Reason can be passed to [Create] to provide a custom reason.
+func Reason(reason string) CreateOption {
+	return func(c *createOptions) {
+		c.reason = reason
+	}
+}
+
+type cancelType Cancel

--- a/tbdex/cancel/cancel_test.go
+++ b/tbdex/cancel/cancel_test.go
@@ -60,7 +60,6 @@ func TestUnmarshal_Invalid(t *testing.T) {
 }
 
 func TestParse(t *testing.T) {
-	// generated using tbdex-dart
 	vector := `{"metadata":{"from":"did:jwk:eyJrdHkiOiJPS1AiLCJjcnYiOiJFZDI1NTE5IiwieCI6InFSUG1TSnRnUmhocklldHphSG1mUnJyaXVMaXhqS29EeDhNeFduREZRaU0ifQ","to":"did:jwk:eyJrdHkiOiJPS1AiLCJjcnYiOiJFZDI1NTE5IiwieCI6ImxqaDdqbUs2WFY2aVktUnZBRVQ1cEhva21Zem9jZnFhVmc0ODc0MHlwOHcifQ","kind":"cancel","id":"cancel_01j2fejf5eenyrt6d6xjdkh7ed","exchangeId":"rfq_01j2fejf5eeny8gycyf1ft8x3j","createdAt":"2024-07-10T23:10:03Z","protocol":"1.0"},"data":{"reason":"I don't want to do this anymore"},"signature":"eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDpqd2s6ZXlKcmRIa2lPaUpQUzFBaUxDSmpjbllpT2lKRlpESTFOVEU1SWl3aWVDSTZJbkZTVUcxVFNuUm5VbWhvY2tsbGRIcGhTRzFtVW5KeWFYVk1hWGhxUzI5RWVEaE5lRmR1UkVaUmFVMGlmUSMwIn0..sn8IoOx3bmAeaaZPPY3i2BqKS0h9Eydrp_Zkx8czQCmOvhNquXBKxMqH2nd2nsK5XuO_Poqv70aHDCAJblCeCg"}`
 
 	c, err := cancel.Parse([]byte(vector))

--- a/tbdex/cancel/cancel_test.go
+++ b/tbdex/cancel/cancel_test.go
@@ -1,0 +1,173 @@
+package cancel_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/TBD54566975/tbdex-go/tbdex/cancel"
+	"github.com/TBD54566975/tbdex-go/tbdex/closemsg"
+	"github.com/TBD54566975/tbdex-go/tbdex/order"
+	"github.com/TBD54566975/tbdex-go/tbdex/orderstatus"
+	"github.com/TBD54566975/tbdex-go/tbdex/quote"
+	"github.com/TBD54566975/tbdex-go/tbdex/rfq"
+
+	"github.com/alecthomas/assert/v2"
+	"github.com/tbd54566975/web5-go/dids/didjwk"
+	"go.jetpack.io/typeid"
+)
+
+func TestUnmarshal(t *testing.T) {
+	vector := `{"metadata":{"from":"did:jwk:eyJrdHkiOiJPS1AiLCJjcnYiOiJFZDI1NTE5IiwieCI6InFSUG1TSnRnUmhocklldHphSG1mUnJyaXVMaXhqS29EeDhNeFduREZRaU0ifQ","to":"did:jwk:eyJrdHkiOiJPS1AiLCJjcnYiOiJFZDI1NTE5IiwieCI6ImxqaDdqbUs2WFY2aVktUnZBRVQ1cEhva21Zem9jZnFhVmc0ODc0MHlwOHcifQ","kind":"cancel","id":"cancel_01j2fejf5eenyrt6d6xjdkh7ed","exchangeId":"rfq_01j2fejf5eeny8gycyf1ft8x3j","createdAt":"2024-07-10T23:10:03Z","protocol":"1.0"},"data":{"reason":"I don't want to do this anymore"},"signature":"eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDpqd2s6ZXlKcmRIa2lPaUpQUzFBaUxDSmpjbllpT2lKRlpESTFOVEU1SWl3aWVDSTZJbkZTVUcxVFNuUm5VbWhvY2tsbGRIcGhTRzFtVW5KeWFYVk1hWGhxUzI5RWVEaE5lRmR1UkVaUmFVMGlmUSMwIn0..sn8IoOx3bmAeaaZPPY3i2BqKS0h9Eydrp_Zkx8czQCmOvhNquXBKxMqH2nd2nsK5XuO_Poqv70aHDCAJblCeCg"}`
+
+	var c cancel.Cancel
+	err := json.Unmarshal([]byte(vector), &c)
+
+	fmt.Println(c.Metadata.CreatedAt)
+
+	assert.NoError(t, err)
+	assert.NotZero(t, c.Metadata)
+	assert.NotZero(t, c.Metadata.To)
+	assert.NotZero(t, c.Metadata.From)
+	assert.NotZero(t, c.Signature)
+	assert.NotZero(t, c.Data)
+}
+
+func TestUnmarshal_Empty(t *testing.T) {
+	vector := `{"metadata":{},"data":{},"signature":"eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDpqd2s6ZXlKcmRIa2lPaUpQUzFBaUxDSmpjbllpT2lKRlpESTFOVEU1SWl3aWVDSTZJbkZTVUcxVFNuUm5VbWhvY2tsbGRIcGhTRzFtVW5KeWFYVk1hWGhxUzI5RWVEaE5lRmR1UkVaUmFVMGlmUSMwIn0..sn8IoOx3bmAeaaZPPY3i2BqKS0h9Eydrp_Zkx8czQCmOvhNquXBKxMqH2nd2nsK5XuO_Poqv70aHDCAJblCeCg"}`
+
+	var c cancel.Cancel
+	_ = json.Unmarshal([]byte(vector), &c)
+
+	assert.Zero(t, c.Metadata)
+	assert.Zero(t, c.Data)
+}
+
+func TestUnmarshal_Invalid(t *testing.T) {
+	vectors := []string{
+		"hi",
+		"{}",
+		"[]",
+		`{"metadata": {"kind": "hoarder"}}`,
+		`{"metadata": {"kind": "hoarder", "from": "hehe"}}`,
+	}
+
+	for _, v := range vectors {
+		var c cancel.Cancel
+		err := json.Unmarshal([]byte(v), &c)
+		assert.Error(t, err)
+	}
+}
+
+func TestParse(t *testing.T) {
+	// generated using tbdex-dart
+	vector := `{"metadata":{"from":"did:jwk:eyJrdHkiOiJPS1AiLCJjcnYiOiJFZDI1NTE5IiwieCI6InFSUG1TSnRnUmhocklldHphSG1mUnJyaXVMaXhqS29EeDhNeFduREZRaU0ifQ","to":"did:jwk:eyJrdHkiOiJPS1AiLCJjcnYiOiJFZDI1NTE5IiwieCI6ImxqaDdqbUs2WFY2aVktUnZBRVQ1cEhva21Zem9jZnFhVmc0ODc0MHlwOHcifQ","kind":"cancel","id":"cancel_01j2fejf5eenyrt6d6xjdkh7ed","exchangeId":"rfq_01j2fejf5eeny8gycyf1ft8x3j","createdAt":"2024-07-10T23:10:03Z","protocol":"1.0"},"data":{"reason":"I don't want to do this anymore"},"signature":"eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDpqd2s6ZXlKcmRIa2lPaUpQUzFBaUxDSmpjbllpT2lKRlpESTFOVEU1SWl3aWVDSTZJbkZTVUcxVFNuUm5VbWhvY2tsbGRIcGhTRzFtVW5KeWFYVk1hWGhxUzI5RWVEaE5lRmR1UkVaUmFVMGlmUSMwIn0..sn8IoOx3bmAeaaZPPY3i2BqKS0h9Eydrp_Zkx8czQCmOvhNquXBKxMqH2nd2nsK5XuO_Poqv70aHDCAJblCeCg"}`
+
+	c, err := cancel.Parse([]byte(vector))
+
+	assert.NoError(t, err)
+	assert.NotZero(t, c.Metadata)
+	assert.NotZero(t, c.Metadata.To)
+	assert.NotZero(t, c.Metadata.From)
+	assert.NotZero(t, c.Signature)
+	assert.NotZero(t, c.Data)
+}
+
+func TestParse_Invalid(t *testing.T) {
+	// signature is kaka
+	vector := `{"metadata":{"from":"did:jwk:eyJrdHkiOiJPS1AiLCJjcnYiOiJFZDI1NTE5IiwieCI6InFSUG1TSnRnUmhocklldHphSG1mUnJyaXVMaXhqS29EeDhNeFduREZRaU0ifQ","to":"did:jwk:eyJrdHkiOiJPS1AiLCJjcnYiOiJFZDI1NTE5IiwieCI6ImxqaDdqbUs2WFY2aVktUnZBRVQ1cEhva21Zem9jZnFhVmc0ODc0MHlwOHcifQ","kind":"cancel","id":"cancel_01j2fejf5eenyrt6d6xjdkh7ed","exchangeId":"rfq_01j2fejf5eeny8gycyf1ft8x3j","createdAt":"2024-07-10T23:10:03Z","protocol":"1.0"},"data":{"reason":"I don't want to do this anymore"},"signature":"lol"}`
+
+	_, err := cancel.Parse([]byte(vector))
+	assert.Error(t, err)
+}
+
+func TestVerify_Invalid(t *testing.T) {
+	// signature is kaka
+	vector := `{"metadata":{"from":"did:jwk:eyJrdHkiOiJPS1AiLCJjcnYiOiJFZDI1NTE5IiwieCI6InFSUG1TSnRnUmhocklldHphSG1mUnJyaXVMaXhqS29EeDhNeFduREZRaU0ifQ","to":"did:jwk:eyJrdHkiOiJPS1AiLCJjcnYiOiJFZDI1NTE5IiwieCI6ImxqaDdqbUs2WFY2aVktUnZBRVQ1cEhva21Zem9jZnFhVmc0ODc0MHlwOHcifQ","kind":"cancel","id":"cancel_01j2fejf5eenyrt6d6xjdkh7ed","exchangeId":"rfq_01j2fejf5eeny8gycyf1ft8x3j","createdAt":"2024-07-10T23:10:03Z","protocol":"1.0"},"data":{"reason":"I don't want to do this anymore"},"signature":"lol"}`
+
+	var c cancel.Cancel
+	err := json.Unmarshal([]byte(vector), &c)
+	assert.NoError(t, err)
+
+	err = c.Verify()
+	assert.Error(t, err)
+}
+
+func TestVerify(t *testing.T) {
+	vector := `{"metadata":{"from":"did:jwk:eyJrdHkiOiJPS1AiLCJjcnYiOiJFZDI1NTE5IiwieCI6InFSUG1TSnRnUmhocklldHphSG1mUnJyaXVMaXhqS29EeDhNeFduREZRaU0ifQ","to":"did:jwk:eyJrdHkiOiJPS1AiLCJjcnYiOiJFZDI1NTE5IiwieCI6ImxqaDdqbUs2WFY2aVktUnZBRVQ1cEhva21Zem9jZnFhVmc0ODc0MHlwOHcifQ","kind":"cancel","id":"cancel_01j2fejf5eenyrt6d6xjdkh7ed","exchangeId":"rfq_01j2fejf5eeny8gycyf1ft8x3j","createdAt":"2024-07-10T23:10:03Z","protocol":"1.0"},"data":{"reason":"I don't want to do this anymore"},"signature":"eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDpqd2s6ZXlKcmRIa2lPaUpQUzFBaUxDSmpjbllpT2lKRlpESTFOVEU1SWl3aWVDSTZJbkZTVUcxVFNuUm5VbWhvY2tsbGRIcGhTRzFtVW5KeWFYVk1hWGhxUzI5RWVEaE5lRmR1UkVaUmFVMGlmUSMwIn0..sn8IoOx3bmAeaaZPPY3i2BqKS0h9Eydrp_Zkx8czQCmOvhNquXBKxMqH2nd2nsK5XuO_Poqv70aHDCAJblCeCg"}`
+
+	var c cancel.Cancel
+	err := json.Unmarshal([]byte(vector), &c)
+	assert.NoError(t, err)
+
+	err = c.Verify()
+	assert.NoError(t, err)
+}
+
+func TestCreate(t *testing.T) {
+	alice, err := didjwk.Create()
+	assert.NoError(t, err)
+
+	pfi, err := didjwk.Create()
+	assert.NoError(t, err)
+
+	exchangeID := typeid.Must(typeid.WithPrefix(rfq.Kind))
+	c, err := cancel.Create(
+		alice,
+		pfi.URI,
+		exchangeID.String(),
+		cancel.Reason("I don't want to do this anymore"),
+	)
+	assert.NoError(t, err)
+
+	j, err := json.MarshalIndent(c, "", "  ")
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(string(j))
+
+	assert.NotZero(t, c)
+	assert.NotZero(t, c.Metadata.ID)
+	assert.Equal(t, alice.URI, c.Metadata.From)
+	assert.Equal(t, pfi.URI, c.Metadata.To)
+	assert.Equal(t, exchangeID.String(), c.Metadata.ExchangeID)
+}
+
+func TestSign(t *testing.T) {
+	alice, err := didjwk.Create()
+	assert.NoError(t, err)
+	pfi, err := didjwk.Create()
+	assert.NoError(t, err)
+
+	exchangeID := typeid.Must(typeid.WithPrefix(rfq.Kind))
+	c, err := cancel.Create(
+		alice,
+		pfi.URI,
+		exchangeID.String(),
+		cancel.Reason("I don't want to do this anymore"),
+	)
+	assert.NoError(t, err)
+
+	err = c.Verify()
+	assert.NoError(t, err)
+}
+
+func TestIsValidNext(t *testing.T) {
+
+	alice, err := didjwk.Create()
+	assert.NoError(t, err)
+	pfi, err := didjwk.Create()
+	assert.NoError(t, err)
+
+	exchangeID := typeid.Must(typeid.WithPrefix(rfq.Kind))
+	c, err := cancel.Create(alice, pfi.URI, exchangeID.String())
+	assert.NoError(t, err)
+
+	assert.False(t, c.IsValidNext(rfq.Kind))
+	assert.False(t, c.IsValidNext(quote.Kind))
+	assert.False(t, c.IsValidNext(order.Kind))
+
+	// cancel can only be followed by orderstatus or close
+	assert.True(t, c.IsValidNext(orderstatus.Kind))
+	assert.True(t, c.IsValidNext(closemsg.Kind))
+}

--- a/tbdex/offering/create.go
+++ b/tbdex/offering/create.go
@@ -17,7 +17,7 @@ import (
 // An Offering is a resource created by a PFI to define requirements for a given currency pair offered for exchange.
 //
 // [Offering]: https://github.com/TBD54566975/tbdex/tree/main/specs/protocol#offering
-func Create(payin *PayinDetails, payout *PayoutDetails, rate string, opts ...CreateOption) (Offering, error) {
+func Create(payin *PayinDetails, payout *PayoutDetails, rate string, cancellationDetails *Cancellation, opts ...CreateOption) (Offering, error) {
 	o := createOptions{
 		id:          typeid.Must(typeid.New[ID]()),
 		createdAt:   time.Now(),
@@ -52,6 +52,7 @@ func Create(payin *PayinDetails, payout *PayoutDetails, rate string, opts ...Cre
 			Rate:           rate,
 			Description:    o.description,
 			RequiredClaims: o.requiredClaims,
+			Cancellation:   cancellationDetails,
 		},
 	}
 
@@ -62,6 +63,19 @@ func Create(payin *PayinDetails, payout *PayoutDetails, rate string, opts ...Cre
 	}
 
 	return offering, nil
+}
+
+func NewCancellationDetails(enabled bool, opts ...CancellationDetailOption) *Cancellation {
+	o := cancellationDetailOptions{}
+	for _, opt := range opts {
+		opt(&o)
+	}
+
+	return &Cancellation{
+		Enabled:  enabled,
+		TermsURL: o.TermsURL,
+		Terms:    o.Terms,
+	}
 }
 
 // NewPayin creates PayinDetails
@@ -180,6 +194,25 @@ func Description(d string) CreateOption {
 func From(d did.BearerDID) CreateOption {
 	return func(o *createOptions) {
 		o.from = &d
+	}
+}
+
+type cancellationDetailOptions struct {
+	TermsURL string
+	Terms    string
+}
+
+type CancellationDetailOption func(*cancellationDetailOptions)
+
+func TermsURL(url string) CancellationDetailOption {
+	return func(o *cancellationDetailOptions) {
+		o.TermsURL = url
+	}
+}
+
+func Terms(terms string) CancellationDetailOption {
+	return func(o *cancellationDetailOptions) {
+		o.Terms = terms
 	}
 }
 

--- a/tbdex/offering/offering.go
+++ b/tbdex/offering/offering.go
@@ -29,6 +29,13 @@ type Data struct {
 	Payin          *PayinDetails                 `json:"payin,omitempty"`
 	Payout         *PayoutDetails                `json:"payout,omitempty"`
 	RequiredClaims *pexv2.PresentationDefinition `json:"requiredClaims,omitempty"`
+	Cancellation   *Cancellation                 `json:"cancellation,omitempty"`
+}
+
+type Cancellation struct {
+	Enabled  bool   `json:"enabled"`
+	TermsURL string `json:"termsUrl,omitempty"`
+	Terms    string `json:"terms,omitempty"`
 }
 
 // PayinDetails represents the details of the payin part of an Offering.

--- a/tbdex/offering/offering_test.go
+++ b/tbdex/offering/offering_test.go
@@ -25,6 +25,7 @@ func TestCreate(t *testing.T) {
 			[]offering.PayoutMethod{offering.NewPayoutMethod("STORED_BALANCE", 20*time.Minute)},
 		),
 		"1.0",
+		offering.NewCancellationDetails(false),
 		offering.From(pfiDID),
 	)
 
@@ -45,6 +46,7 @@ func TestSign(t *testing.T) {
 			[]offering.PayoutMethod{offering.NewPayoutMethod("STORED_BALANCE", 20*time.Minute)},
 		),
 		"1.0",
+		offering.NewCancellationDetails(false),
 		offering.From(bearerDID),
 	)
 	assert.NoError(t, err)
@@ -81,6 +83,7 @@ func TestUnmarshal(t *testing.T) {
 			)},
 		),
 		"1.0",
+		offering.NewCancellationDetails(false),
 		offering.From(bearerDID),
 	)
 
@@ -126,6 +129,7 @@ func TestVerify(t *testing.T) {
 			[]offering.PayoutMethod{offering.NewPayoutMethod("STORED_BALANCE", 20*time.Minute)},
 		),
 		"60000.00",
+		offering.NewCancellationDetails(false),
 		offering.From(bearerDID),
 	)
 
@@ -149,6 +153,7 @@ func TestVerify_InvalidSignature(t *testing.T) {
 			[]offering.PayoutMethod{offering.NewPayoutMethod("STORED_BALANCE", 20*time.Minute)},
 		),
 		"60000.00",
+		offering.NewCancellationDetails(false),
 		offering.From(bearerDID),
 	)
 
@@ -174,6 +179,7 @@ func TestVerify_SignedWithWrongDID(t *testing.T) {
 			[]offering.PayoutMethod{offering.NewPayoutMethod("STORED_BALANCE", 20*time.Minute)},
 		),
 		"60000.00",
+		offering.NewCancellationDetails(false),
 		offering.From(bearerDID),
 	)
 

--- a/tbdex/order/order.go
+++ b/tbdex/order/order.go
@@ -20,7 +20,7 @@ const Kind = "order"
 
 // ValidNext returns the valid message kinds that can follow an order.
 func ValidNext() []string {
-	return []string{orderstatus.Kind, closemsg.Kind}
+	return []string{orderstatus.Kind, closemsg.Kind, cancel.Kind}
 }
 
 // Order represents a tbdex [order] message.
@@ -44,7 +44,7 @@ func (o Order) GetKind() string {
 
 // GetValidNext returns the valid message kinds that can follow an order.
 func (o Order) GetValidNext() []string {
-	return []string{orderstatus.Kind, closemsg.Kind, cancel.Kind}
+	return ValidNext()
 }
 
 // IsValidNext checks if the kind is a valid next message kind for an order.

--- a/tbdex/order/order.go
+++ b/tbdex/order/order.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/TBD54566975/tbdex-go/tbdex/cancel"
 	"github.com/TBD54566975/tbdex-go/tbdex/closemsg"
 	"github.com/TBD54566975/tbdex-go/tbdex/crypto"
 	"github.com/TBD54566975/tbdex-go/tbdex/message"
@@ -43,7 +44,7 @@ func (o Order) GetKind() string {
 
 // GetValidNext returns the valid message kinds that can follow an order.
 func (o Order) GetValidNext() []string {
-	return []string{orderstatus.Kind, closemsg.Kind}
+	return []string{orderstatus.Kind, closemsg.Kind, cancel.Kind}
 }
 
 // IsValidNext checks if the kind is a valid next message kind for an order.
@@ -55,6 +56,7 @@ func (o Order) IsValidNext(kind string) bool {
 	}
 	return false
 }
+
 // Data represents the data field of an order message.
 // Note that this is intentionally left empty as per the spec
 type Data struct{}

--- a/tbdex/orderstatus/orderstatus.go
+++ b/tbdex/orderstatus/orderstatus.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/TBD54566975/tbdex-go/tbdex/cancel"
 	"github.com/TBD54566975/tbdex-go/tbdex/closemsg"
 	"github.com/TBD54566975/tbdex-go/tbdex/crypto"
 	"github.com/TBD54566975/tbdex-go/tbdex/message"
@@ -18,7 +19,7 @@ const Kind = "orderstatus"
 
 // ValidNext returns the valid next message kinds that can follow an orderstatus
 func ValidNext() []string {
-	return []string{Kind, closemsg.Kind}
+	return []string{Kind, closemsg.Kind, cancel.Kind}
 }
 
 // OrderStatus represents an order status message within the exchange.
@@ -40,7 +41,7 @@ func (os OrderStatus) GetKind() string {
 
 // GetValidNext returns the valid next message kinds that can follow an orderstatus
 func (os OrderStatus) GetValidNext() []string {
-	return []string{Kind, closemsg.Kind}
+	return ValidNext()
 }
 
 // IsValidNext checks if the kind is a valid next message kind for an orderstatus

--- a/tbdex/quote/quote.go
+++ b/tbdex/quote/quote.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/TBD54566975/tbdex-go/tbdex/cancel"
 	"github.com/TBD54566975/tbdex-go/tbdex/closemsg"
 	"github.com/TBD54566975/tbdex-go/tbdex/crypto"
 	"github.com/TBD54566975/tbdex-go/tbdex/message"
@@ -20,7 +21,7 @@ const Kind = "quote"
 
 // ValidNext returns the valid message kinds that can follow a Quote.
 func ValidNext() []string {
-	return []string{order.Kind, closemsg.Kind}
+	return []string{order.Kind, closemsg.Kind, cancel.Kind}
 }
 
 // Quote represents a quote message within the exchange.

--- a/tbdex/quote/quote_test.go
+++ b/tbdex/quote/quote_test.go
@@ -209,8 +209,8 @@ func TestIsValidNext(t *testing.T) {
 		rfqID.String(),
 		time.Now().UTC().Format(time.RFC3339),
 		"16.665",
-		quote.NewQuoteDetails("USD", decimal.RequireFromString("10")),
-		quote.NewQuoteDetails("MXN", decimal.RequireFromString("500")),
+		quote.NewQuoteDetails("USD", decimal.RequireFromString("10"), quote.DetailsInstruction(quote.NewPaymentInstruction(quote.Instruction("use link provided")))),
+		quote.NewQuoteDetails("MXN", decimal.RequireFromString("500"), quote.DetailsInstruction(quote.NewPaymentInstruction(quote.Instruction("SPEI transfer")))),
 	)
 	assert.NoError(t, err)
 

--- a/tbdex/rfq/rfq.go
+++ b/tbdex/rfq/rfq.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/TBD54566975/tbdex-go/tbdex/cancel"
 	"github.com/TBD54566975/tbdex-go/tbdex/closemsg"
 	"github.com/TBD54566975/tbdex-go/tbdex/crypto"
 	"github.com/TBD54566975/tbdex-go/tbdex/message"
@@ -24,7 +25,7 @@ const Kind = "rfq"
 
 // ValidNext returns the valid message kinds that can follow a RFQ.
 func ValidNext() []string {
-	return []string{quote.Kind, closemsg.Kind}
+	return []string{quote.Kind, closemsg.Kind, cancel.Kind}
 }
 
 // RFQ represents a request for quote message within the exchange.

--- a/tbdex/rfq/rfq.go
+++ b/tbdex/rfq/rfq.go
@@ -224,8 +224,9 @@ func (rfq *RFQ) VerifyOfferingRequirements(offering _offering.Offering) error {
 	}
 
 	if offering.Data.RequiredClaims != nil {
-		if err := rfq.verifyClaims(offering.Data.RequiredClaims); err != nil {
-			return fmt.Errorf("rfq claims do not satisfy offering's requirements")
+		err := rfq.verifyClaims(offering.Data.RequiredClaims)
+		if err != nil {
+			return fmt.Errorf("rfq claims do not satisfy offering's requirements. %w", err)
 		}
 	}
 

--- a/tbdex/rfq/rfq_test.go
+++ b/tbdex/rfq/rfq_test.go
@@ -445,6 +445,7 @@ func TestVerifyOfferingRequirements(t *testing.T) {
 				[]offering.PayoutMethod{offering.NewPayoutMethod("STORED_BALANCE", 20*time.Minute)},
 			),
 			"1.0",
+			offering.NewCancellationDetails(false),
 			offering.From(pfiDID),
 		)
 
@@ -621,6 +622,7 @@ func TestVerifyOfferingRequirements(t *testing.T) {
 				[]offering.PayoutMethod{offering.NewPayoutMethod("STORED_BALANCE", 20*time.Minute)},
 			),
 			"16.0",
+			offering.NewCancellationDetails(false),
 			offering.From(pfiDID),
 		)
 		assert.NoError(t, err)
@@ -666,6 +668,7 @@ func TestVerifyOfferingRequirements(t *testing.T) {
 				[]offering.PayoutMethod{offering.NewPayoutMethod("STORED_BALANCE", 20*time.Minute)},
 			),
 			"1.0",
+			offering.NewCancellationDetails(false),
 			offering.From(pfiDID),
 		)
 		assert.NoError(t, err)
@@ -723,6 +726,7 @@ func TestVerifyOfferingRequirements(t *testing.T) {
 				[]offering.PayoutMethod{offering.NewPayoutMethod("STORED_BALANCE", 20*time.Minute)},
 			),
 			"1.0",
+			offering.NewCancellationDetails(false),
 			offering.From(pfiDID),
 			offering.RequiredClaims(pd),
 		)
@@ -778,6 +782,7 @@ func TestVerifyOfferingRequirements(t *testing.T) {
 				[]offering.PayoutMethod{offering.NewPayoutMethod("STORED_BALANCE", 20*time.Minute)},
 			),
 			"1.0",
+			offering.NewCancellationDetails(false),
 			offering.From(pfiDID),
 			offering.RequiredClaims(pd),
 		)
@@ -835,6 +840,7 @@ func TestVerifyOfferingRequirements(t *testing.T) {
 				[]offering.PayoutMethod{offering.NewPayoutMethod("STORED_BALANCE", 20*time.Minute)},
 			),
 			"1.0",
+			offering.NewCancellationDetails(false),
 			offering.From(pfiDID),
 			offering.RequiredClaims(pd),
 		)

--- a/tbdex/validator/json-schemas/cancel.schema.json
+++ b/tbdex/validator/json-schemas/cancel.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://tbdex.dev/close.schema.json",
+    "$id": "https://tbdex.dev/cancel.schema.json",
     "type": "object",
     "additionalProperties": false,
     "properties": {

--- a/tbdex/validator/json-schemas/cancel.schema.json
+++ b/tbdex/validator/json-schemas/cancel.schema.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://tbdex.dev/close.schema.json",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "reason": {
+        "type": "string"
+      }
+    }
+  }

--- a/tbdex/validator/json-schemas/message.schema.json
+++ b/tbdex/validator/json-schemas/message.schema.json
@@ -16,7 +16,7 @@
         },
         "kind": {
           "type": "string",
-          "enum": ["rfq", "quote", "order", "orderstatus", "close"],
+          "enum": ["rfq", "quote", "order", "orderstatus", "close", "cancel"],
           "description": "The message kind (e.g. rfq, quote)"
         },
         "id": {

--- a/tbdex/validator/json-schemas/offering.schema.json
+++ b/tbdex/validator/json-schemas/offering.schema.json
@@ -142,12 +142,31 @@
     "requiredClaims": {
       "type": "object",
       "description": "PresentationDefinition that describes the credential(s) the PFI requires in order to provide a quote."
+    },
+    "cancellation": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether cancellation is enabled for this offering"
+        },
+        "terms_url": {
+          "type": "string",
+          "description": "A link to a page that describes the terms of cancellation"
+        },
+        "terms": {
+          "type": "string",
+          "description": "A human-readable description of the terms of cancellation in plaintext"
+        }
+      },
+      "required": ["enabled"]
     }
   },
   "required": [
     "description",
     "payin",
     "payout",
-    "payoutUnitsPerPayinUnit"
+    "payoutUnitsPerPayinUnit",
+    "cancellation"
   ]
 }

--- a/tbdex/validator/json-schemas/offering.schema.json
+++ b/tbdex/validator/json-schemas/offering.schema.json
@@ -150,7 +150,7 @@
           "type": "boolean",
           "description": "Whether cancellation is enabled for this offering"
         },
-        "terms_url": {
+        "termsUrl": {
           "type": "string",
           "description": "A link to a page that describes the terms of cancellation"
         },


### PR DESCRIPTION
## changes
* add cancel message
* update offering to include `cancellation` object
* logging error for rfq.VerifyClaims() as it was swallowing the error returned from internal calls
