### PR TITLE
Add tbdex go to sdk report runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,14 +22,15 @@ jobs:
         with:
           cache: true
 
+      - name: Install go-junit-report
+        run: go install github.com/jstemmer/go-junit-report@latest
+
       - name: Build Cache
         uses: ./.github/actions/build-cache
 
-      - name: Test
-        run: just test
-
-      - name: Test With XML Reporting
-        run: just test-xml
+      - name: Run Tests with XML Reporting
+        run: |
+          just test-xml
 
       - name: Upload Tbdex Go Test Results
         uses: actions/upload-artifact@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,13 @@ jobs:
 
       - name: Test
         run: just test
+
+      - name: Upload Tbdex Go Test Results
+        uses: actions/upload-artifact@v3
+        with:
+          name: go-test-results
+          path: '**/report.xml'
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Test
         run: just test
 
+      - name: Test With XML Reporting
+        run: just test-xml
+
       - name: Upload Tbdex Go Test Results
         uses: actions/upload-artifact@v3
         with:

--- a/Justfile
+++ b/Justfile
@@ -10,7 +10,7 @@ test:
 # Run all tests with XML reporting.
 test-xml:
   find . -name go.mod | grep -v /_ | xargs -n1 dirname | xargs -n1 -I{} sh -c 'cd {} && go test -v 2>&1 ./...| go-junit-report -set-exit-code > report.xml'
-  find . -name report.xml | xargs sed -i "s/name=\"github.com\/TBD54566975\/tbdex-go\/tbdex\">/name=\"TbdexTestVectors\">/g"
+  find . -name report.xml | xargs sed -i "s/name=\"github.com\/TBD54566975\/tbdex-go\/tbdex\">/name=\"TbdexProtocolTestVectors\">/g"
 
 lint:
   @echo "Running linter..."

--- a/Justfile
+++ b/Justfile
@@ -9,7 +9,8 @@ test:
 
 # Run all tests with XML reporting.
 test-xml:
-  find . -name go.mod | grep -v /_ | xargs -n1 dirname | xargs -n1 -I{} sh -c 'cd {} && go test -v 2>&1 ./... | go-junit-report -set-exit-code > report.xml && sed -i "" "s/name=\"github.com\/TBD54566975\/tbdex-go\/tbdex\">/name=\"TbdexTestVector\">/g" report.xml'
+  find . -name go.mod | grep -v /_ | xargs -n1 dirname | xargs -n1 -I{} sh -c 'cd {} && go test -v 2>&1 ./...| go-junit-report -set-exit-code > report.xml'
+  find . -name report.xml | xargs sed -i "s/name=\"github.com\/TBD54566975\/tbdex-go\/tbdex\">/name=\"TbdexTestVector\">/g"
 
 lint:
   @echo "Running linter..."

--- a/Justfile
+++ b/Justfile
@@ -10,7 +10,7 @@ test:
 # Run all tests with XML reporting.
 test-xml:
   find . -name go.mod | grep -v /_ | xargs -n1 dirname | xargs -n1 -I{} sh -c 'cd {} && go test -v 2>&1 ./...| go-junit-report -set-exit-code > report.xml'
-  find . -name report.xml | xargs sed -i "s/name=\"github.com\/TBD54566975\/tbdex-go\/tbdex\">/name=\"TbdexProtocolTestVectors\">/g"
+  find . -name report.xml | xargs sed -i "s/name=\"github.com\/TBD54566975\/tbdex-go\/tbdex\">/name=\"TbdexTestVectorsProtocol\">/g"
 
 lint:
   @echo "Running linter..."

--- a/Justfile
+++ b/Justfile
@@ -9,7 +9,7 @@ test:
 
 # Run all tests with XML reporting.
 test-xml:
-  find . -name go.mod | grep -v /_ | xargs -n1 dirname | xargs -n1 -I{} sh -c 'cd {} && go test -v 2>&1 ./...| go-junit-report -set-exit-code > report.xml'
+  find . -name go.mod | grep -v /_ | xargs -n1 dirname | xargs -n1 -I{} sh -c 'cd {} && go test -v 2>&1 ./... | go-junit-report -set-exit-code > report.xml && sed -i "" "s/name=\"github.com\/TBD54566975\/tbdex-go\/tbdex\">/name=\"TbdexTestVector\">/g" report.xml'
 
 lint:
   @echo "Running linter..."

--- a/Justfile
+++ b/Justfile
@@ -10,7 +10,7 @@ test:
 # Run all tests with XML reporting.
 test-xml:
   find . -name go.mod | grep -v /_ | xargs -n1 dirname | xargs -n1 -I{} sh -c 'cd {} && go test -v 2>&1 ./...| go-junit-report -set-exit-code > report.xml'
-  find . -name report.xml | xargs sed -i "s/name=\"github.com\/TBD54566975\/tbdex-go\/tbdex\">/name=\"TbdexTestVector\">/g"
+  find . -name report.xml | xargs sed -i "s/name=\"github.com\/TBD54566975\/tbdex-go\/tbdex\">/name=\"TbdexTestVectors\">/g"
 
 lint:
   @echo "Running linter..."

--- a/tbdex/vectors_test.go
+++ b/tbdex/vectors_test.go
@@ -38,7 +38,7 @@ func readVector(filename string) vector {
 	return v
 }
 
-func TestOfferingVectors(t *testing.T) {
+func TestOfferingTbdexTestVectors(t *testing.T) {
 	vector := readVector("parse-offering.json")
 	res := offering.Offering{}
 	err := res.Parse([]byte(vector.Input))
@@ -46,14 +46,14 @@ func TestOfferingVectors(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestBalanceVectors(t *testing.T) {
+func TestBalanceTbdexTestVectors(t *testing.T) {
 	vector := readVector("parse-balance.json")
 	_, err := balance.Parse([]byte(vector.Input))
 
 	assert.NoError(t, err)
 }
 
-func TestRFQVectors(t *testing.T) {
+func TestRFQTbdexTestVectors(t *testing.T) {
 	vector := readVector("parse-rfq.json")
 	_, err := rfq.Parse([]byte(vector.Input))
 
@@ -65,35 +65,35 @@ func TestRFQVectors(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestQuoteVectors(t *testing.T) {
+func TestQuoteTbdexTestVectors(t *testing.T) {
 	vector := readVector("parse-quote.json")
 	_, err := quote.Parse([]byte(vector.Input))
 
 	assert.NoError(t, err)
 }
 
-func TestOrderVectors(t *testing.T) {
+func TestOrderTbdexTestVectors(t *testing.T) {
 	vector := readVector("parse-order.json")
 	_, err := order.Parse([]byte(vector.Input))
 
 	assert.NoError(t, err)
 }
 
-func TestOrderStatusVectors(t *testing.T) {
+func TestOrderStatusTbdexTestVectors(t *testing.T) {
 	vector := readVector("parse-orderstatus.json")
 	_, err := orderstatus.Parse([]byte(vector.Input))
 
 	assert.NoError(t, err)
 }
 
-func TestCloseVectors(t *testing.T) {
+func TestCloseTbdexTestVectors(t *testing.T) {
 	vector := readVector("parse-close.json")
 	_, err := closemsg.Parse([]byte(vector.Input))
 
 	assert.NoError(t, err)
 }
 
-func TestCancelVectors(t *testing.T) {
+func TestCancelTbdexTestVectors(t *testing.T) {
 	vector := readVector("parse-cancel.json")
 	_, err := cancel.Parse([]byte(vector.Input))
 

--- a/tbdex/vectors_test.go
+++ b/tbdex/vectors_test.go
@@ -38,7 +38,7 @@ func readVector(filename string) vector {
 	return v
 }
 
-func TestOfferingTbdexTestVectors(t *testing.T) {
+func parse_offering(t *testing.T) {
 	vector := readVector("parse-offering.json")
 	res := offering.Offering{}
 	err := res.Parse([]byte(vector.Input))
@@ -46,14 +46,14 @@ func TestOfferingTbdexTestVectors(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestBalanceTbdexTestVectors(t *testing.T) {
+func parse_balance(t *testing.T) {
 	vector := readVector("parse-balance.json")
 	_, err := balance.Parse([]byte(vector.Input))
 
 	assert.NoError(t, err)
 }
 
-func TestRFQTbdexTestVectors(t *testing.T) {
+func parse_rfq(t *testing.T) {
 	vector := readVector("parse-rfq.json")
 	_, err := rfq.Parse([]byte(vector.Input))
 
@@ -65,37 +65,48 @@ func TestRFQTbdexTestVectors(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestQuoteTbdexTestVectors(t *testing.T) {
+func parse_quote(t *testing.T) {
 	vector := readVector("parse-quote.json")
 	_, err := quote.Parse([]byte(vector.Input))
 
 	assert.NoError(t, err)
 }
 
-func TestOrderTbdexTestVectors(t *testing.T) {
+func parse_order(t *testing.T) {
 	vector := readVector("parse-order.json")
 	_, err := order.Parse([]byte(vector.Input))
 
 	assert.NoError(t, err)
 }
 
-func TestOrderStatusTbdexTestVectors(t *testing.T) {
+func parse_orderstatus(t *testing.T) {
 	vector := readVector("parse-orderstatus.json")
 	_, err := orderstatus.Parse([]byte(vector.Input))
 
 	assert.NoError(t, err)
 }
 
-func TestCloseTbdexTestVectors(t *testing.T) {
+func parse_close(t *testing.T) {
 	vector := readVector("parse-close.json")
 	_, err := closemsg.Parse([]byte(vector.Input))
 
 	assert.NoError(t, err)
 }
 
-func TestCancelTbdexTestVectors(t *testing.T) {
+func parse_cancel(t *testing.T) {
 	vector := readVector("parse-cancel.json")
 	_, err := cancel.Parse([]byte(vector.Input))
 
 	assert.NoError(t, err)
+}
+
+func TestAllParsers(t *testing.T) {
+	t.Run("parse_offering", parse_offering)
+	t.Run("parse_balance", parse_balance)
+	t.Run("parse_rfq", parse_rfq)
+	t.Run("parse_quote", parse_quote)
+	t.Run("parse_order", parse_order)
+	t.Run("parse_orderstatus", parse_orderstatus)
+	t.Run("parse_close", parse_close)
+	t.Run("parse_cancel", parse_cancel)
 }


### PR DESCRIPTION
This change changes the naming of the test vectors tests, so that the report runner can pick them up and display a ✅  in our https://github.com/TBD54566975/sdk-report-runner repo.

This also adds a github action to produce a junit artifact in the actions of the github repo